### PR TITLE
Add whole route metrics for netlink

### DIFF
--- a/route.go
+++ b/route.go
@@ -46,8 +46,21 @@ type Route struct {
 	NewDst     Destination
 	Encap      Encap
 	MTU        int
+	Window     int
+	Rtt        int
+	RttVar     int
+	Ssthresh   int
+	Cwnd       int
 	AdvMSS     int
+	Reordering int
 	Hoplimit   int
+	InitCwnd   int
+	Features   int
+	RtoMin     int
+	InitRwnd   int
+	QuickACK   int
+	Congctl    string
+	FastOpenNoCookie int
 }
 
 func (r Route) String() string {

--- a/route_linux.go
+++ b/route_linux.go
@@ -642,18 +642,69 @@ func (h *Handle) routeHandle(route *Route, req *nl.NetlinkRequest, msg *nl.RtMsg
 	}
 
 	var metrics []*nl.RtAttr
-	// TODO: support other rta_metric values
 	if route.MTU > 0 {
 		b := nl.Uint32Attr(uint32(route.MTU))
 		metrics = append(metrics, nl.NewRtAttr(unix.RTAX_MTU, b))
+	}
+	if route.Window > 0 {
+		b := nl.Uint32Attr(uint32(route.Window))
+		metrics = append(metrics, nl.NewRtAttr(unix.RTAX_WINDOW, b))
+	}
+	if route.Rtt > 0 {
+		b := nl.Uint32Attr(uint32(route.Rtt))
+		metrics = append(metrics, nl.NewRtAttr(unix.RTAX_RTT, b))
+	}
+	if route.RttVar > 0 {
+		b := nl.Uint32Attr(uint32(route.RttVar))
+		metrics = append(metrics, nl.NewRtAttr(unix.RTAX_RTTVAR, b))
+	}
+	if route.Ssthresh > 0 {
+		b := nl.Uint32Attr(uint32(route.Ssthresh))
+		metrics = append(metrics, nl.NewRtAttr(unix.RTAX_SSTHRESH, b))
+	}
+	if route.Cwnd > 0 {
+		b := nl.Uint32Attr(uint32(route.Cwnd))
+		metrics = append(metrics, nl.NewRtAttr(unix.RTAX_CWND, b))
 	}
 	if route.AdvMSS > 0 {
 		b := nl.Uint32Attr(uint32(route.AdvMSS))
 		metrics = append(metrics, nl.NewRtAttr(unix.RTAX_ADVMSS, b))
 	}
+	if route.Reordering > 0 {
+		b := nl.Uint32Attr(uint32(route.Reordering))
+		metrics = append(metrics, nl.NewRtAttr(unix.RTAX_REORDERING, b))
+	}
 	if route.Hoplimit > 0 {
 		b := nl.Uint32Attr(uint32(route.Hoplimit))
 		metrics = append(metrics, nl.NewRtAttr(unix.RTAX_HOPLIMIT, b))
+	}
+	if route.InitCwnd > 0 {
+		b := nl.Uint32Attr(uint32(route.InitCwnd))
+		metrics = append(metrics, nl.NewRtAttr(unix.RTAX_INITCWND, b))
+	}
+	if route.Features > 0 {
+		b := nl.Uint32Attr(uint32(route.Features))
+		metrics = append(metrics, nl.NewRtAttr(unix.RTAX_FEATURES, b))
+	}
+	if route.RtoMin > 0 {
+		b := nl.Uint32Attr(uint32(route.RtoMin))
+		metrics = append(metrics, nl.NewRtAttr(unix.RTAX_RTO_MIN, b))
+	}
+	if route.InitRwnd > 0 {
+		b := nl.Uint32Attr(uint32(route.InitRwnd))
+		metrics = append(metrics, nl.NewRtAttr(unix.RTAX_INITRWND, b))
+	}
+	if route.QuickACK > 0 {
+		b := nl.Uint32Attr(uint32(route.QuickACK))
+		metrics = append(metrics, nl.NewRtAttr(unix.RTAX_QUICKACK, b))
+	}
+	if route.Congctl != "" {
+		b := nl.ZeroTerminated(route.Congctl)
+		metrics = append(metrics, nl.NewRtAttr(unix.RTAX_CC_ALGO, b))
+	}
+	if route.FastOpenNoCookie > 0 {
+		b := nl.Uint32Attr(uint32(route.FastOpenNoCookie))
+		metrics = append(metrics, nl.NewRtAttr(unix.RTAX_FASTOPEN_NO_COOKIE, b))
 	}
 
 	if metrics != nil {
@@ -906,10 +957,36 @@ func deserializeRoute(m []byte) (Route, error) {
 				switch metric.Attr.Type {
 				case unix.RTAX_MTU:
 					route.MTU = int(native.Uint32(metric.Value[0:4]))
+				case unix.RTAX_WINDOW:
+					route.Window = int(native.Uint32(metric.Value[0:4]))
+				case unix.RTAX_RTT:
+					route.Rtt = int(native.Uint32(metric.Value[0:4]))
+				case unix.RTAX_RTTVAR:
+					route.RttVar = int(native.Uint32(metric.Value[0:4]))
+				case unix.RTAX_SSTHRESH:
+					route.Ssthresh = int(native.Uint32(metric.Value[0:4]))
+				case unix.RTAX_CWND:
+					route.Cwnd = int(native.Uint32(metric.Value[0:4]))
 				case unix.RTAX_ADVMSS:
 					route.AdvMSS = int(native.Uint32(metric.Value[0:4]))
+				case unix.RTAX_REORDERING:
+					route.Reordering = int(native.Uint32(metric.Value[0:4]))
 				case unix.RTAX_HOPLIMIT:
 					route.Hoplimit = int(native.Uint32(metric.Value[0:4]))
+				case unix.RTAX_INITCWND:
+					route.InitCwnd = int(native.Uint32(metric.Value[0:4]))
+				case unix.RTAX_FEATURES:
+					route.Features = int(native.Uint32(metric.Value[0:4]))
+				case unix.RTAX_RTO_MIN:
+					route.RtoMin = int(native.Uint32(metric.Value[0:4]))
+				case unix.RTAX_INITRWND:
+					route.InitRwnd = int(native.Uint32(metric.Value[0:4]))
+				case unix.RTAX_QUICKACK:
+					route.QuickACK = int(native.Uint32(metric.Value[0:4]))
+				case unix.RTAX_CC_ALGO:
+					route.Congctl = nl.BytesToString(metric.Value)
+				case unix.RTAX_FASTOPEN_NO_COOKIE:
+					route.FastOpenNoCookie = int(native.Uint32(metric.Value[0:4]))
 				}
 			}
 		}


### PR DESCRIPTION
There are lots of route metrics to be added, such as rto_min,
quick_ack and so on, and these metrics are useful for users to
tune network performance, so we add all these metrics.

Signed-off-by: bianze <bianze1993@gmail.com>